### PR TITLE
switch to shared opus files

### DIFF
--- a/graph/crud.py
+++ b/graph/crud.py
@@ -24,3 +24,12 @@ def get_by_pk(item_id: str, sort_key: str):
     )
 
     return result
+
+
+def get_opus(tones):
+    result = table.query(
+        KeyConditionExpression=f"pk = :pk and sk = :sort_key",
+        ExpressionAttributeValues={":pk": "opus", ":sort_key": tones},
+    )
+
+    return result["Items"][0]["opus"].value.decode("utf-8")

--- a/graph/schema.py
+++ b/graph/schema.py
@@ -34,11 +34,12 @@ def get_items(pk: str, sk: str):
 
 def get_song(song_id: str):
     data = crud.get_by_pk(song_id, "name")["Items"][0]
+    opus = crud.get_opus(data["tones"])
     return Song(
         id=data["pk"],
         name=data["name"],
         tones=data["tones"],
-        opus=data["opus"].value.decode("utf-8"),
+        opus=opus,
     )
 
 


### PR DESCRIPTION
There no longer are song-specific opus files, but rather shared ones to save space and compute when adding songs. I.e. there is now one record in the DB e.g. for tones D4-Bb3-F3-Bb2, which gets sent to the user when they request a song that has that particular set of starting tones. 