### PR TITLE
9 fully featured api

### DIFF
--- a/graph/lib/crud.py
+++ b/graph/lib/crud.py
@@ -2,8 +2,14 @@ from functools import partial
 from typing import Type
 
 from .models import CreateModelType, UpdateModelType, ModelType
-from .models import Song, Composer, Collection, Membership
+from .models import Song, Composer, Collection, Membership, SearchResult
 from . import dynamodb as db
+
+
+def search(kind: str, string: str) -> SearchResult:
+    items = db.search(kind, string)
+
+    return [SearchResult(**item) for item in items]
 
 
 def create(data: CreateModelType, model: Type[ModelType]) -> ModelType:

--- a/graph/lib/crud.py
+++ b/graph/lib/crud.py
@@ -29,6 +29,12 @@ def read(id: int, model: Type[ModelType]) -> ModelType:
     return model(**item)
 
 
+def read_all(model: Type[ModelType]) -> ModelType:
+    items = db.get_partition(model.__kind__)
+
+    return [model(**item) for item in items]
+
+
 def update(id: int, data: UpdateModelType, model: Type[ModelType]) -> ModelType:
     kind = model.__kind__
     db_record = db.get_item(kind, f"{kind}:{id}")
@@ -61,6 +67,10 @@ create_collection = partial(create, model=Collection)
 read_song = partial(read, model=Song)
 read_composer = partial(read, model=Composer)
 read_collection = partial(read, model=Collection)
+
+read_all_songs = partial(read_all, model=Song)
+read_all_composers = partial(read_all, model=Composer)
+read_all_collections = partial(read_all, model=Collection)
 
 update_song = partial(update, model=Song)
 update_composer = partial(update, model=Composer)

--- a/graph/lib/crud.py
+++ b/graph/lib/crud.py
@@ -2,7 +2,7 @@ from functools import partial
 from typing import Type
 
 from .models import CreateModelType, UpdateModelType, ModelType
-from .models import Song, Composer, Collection
+from .models import Song, Composer, Collection, Membership
 from . import dynamodb as db
 
 
@@ -58,6 +58,12 @@ def delete(id: int, model: Type[ModelType]) -> ModelType:
     return model(**db.delete(pk, sk))
 
 
+def get_group_songs(id: int, kind: str) -> list[Membership]:
+    items = db.get_partition(f"{kind}:{id}")
+
+    return [Membership(**item) for item in items]
+
+
 # these do not properly bind to the appropriate create and update types, but
 # this shall be considered later
 create_song = partial(create, model=Song)
@@ -71,9 +77,11 @@ read_composer = partial(read, model=Composer)
 read_all_composers = partial(read_all, model=Composer)
 update_composer = partial(update, model=Composer)
 delete_composer = partial(delete, model=Composer)
+get_composer_songs = partial(get_group_songs, kind="composer")
 
 create_collection = partial(create, model=Collection)
 read_collection = partial(read, model=Collection)
 read_all_collections = partial(read_all, model=Collection)
 update_collection = partial(update, model=Collection)
 delete_collection = partial(delete, model=Collection)
+get_collection_songs = partial(get_group_songs, kind="collection")

--- a/graph/lib/crud.py
+++ b/graph/lib/crud.py
@@ -70,6 +70,15 @@ def get_group_songs(id: int, kind: str) -> list[Membership]:
     return [Membership(**item) for item in items]
 
 
+def delete_group_cascade(id: int, kind: str) -> int:
+    # using the lower-level ProjectionExpression here isn't all that nice
+    keys = db.get_partition(f"{kind}:{id}", ProjectionExpression="pk, sk")
+
+    db.batch_delete([*keys, {"pk": kind, "sk": f"{kind}:{id}"}])
+
+    return id
+
+
 # these do not properly bind to the appropriate create and update types, but
 # this shall be considered later
 create_song = partial(create, model=Song)
@@ -97,6 +106,7 @@ read_all_composers = partial(read_all, model=Composer)
 update_composer = partial(update, model=Composer)
 delete_composer = partial(delete, model=Composer)
 get_composer_songs = partial(get_group_songs, kind="composer")
+delete_composer_cascade = partial(delete_group_cascade, kind="composer")
 
 create_collection = partial(create, model=Collection)
 read_collection = partial(read, model=Collection)
@@ -104,6 +114,7 @@ read_all_collections = partial(read_all, model=Collection)
 update_collection = partial(update, model=Collection)
 delete_collection = partial(delete, model=Collection)
 get_collection_songs = partial(get_group_songs, kind="collection")
+delete_collection_cascade = partial(delete_group_cascade, kind="collection")
 
 
 def create_memberships(

--- a/graph/lib/crud.py
+++ b/graph/lib/crud.py
@@ -90,3 +90,31 @@ read_all_collections = partial(read_all, model=Collection)
 update_collection = partial(update, model=Collection)
 delete_collection = partial(delete, model=Collection)
 get_collection_songs = partial(get_group_songs, kind="collection")
+
+
+def create_memberships(
+    kind: str, group_id: int, song_ids: list[int]
+) -> list[Membership]:
+    songs = db.batch_get([{"pk": "song", "sk": f"song:{id}"} for id in song_ids])
+
+    items = [
+        Membership(
+            pk=f"{kind}:{group_id}",
+            sk=song["sk"],
+            name=song["name"],
+            tones=song["tones"],
+        )
+        for song in songs
+    ]
+
+    db.batch_write([item.model_dump() for item in items])
+
+    return items
+
+
+def delete_memberships(kind: str, group_id: int, song_ids: list[int]) -> list[dict]:
+    deleted = db.batch_delete(
+        [{"pk": f"{kind}:{group_id}", "sk": f"song:{id}"} for id in song_ids]
+    )
+
+    return deleted

--- a/graph/lib/crud.py
+++ b/graph/lib/crud.py
@@ -72,6 +72,11 @@ read_all_songs = partial(read_all, model=Song)
 update_song = partial(update, model=Song)
 delete_song = partial(delete, model=Song)
 
+
+def get_random_song() -> Song:
+    return Song(**db.random("song"))
+
+
 create_composer = partial(create, model=Composer)
 read_composer = partial(read, model=Composer)
 read_all_composers = partial(read_all, model=Composer)

--- a/graph/lib/crud.py
+++ b/graph/lib/crud.py
@@ -61,21 +61,19 @@ def delete(id: int, model: Type[ModelType]) -> ModelType:
 # these do not properly bind to the appropriate create and update types, but
 # this shall be considered later
 create_song = partial(create, model=Song)
-create_composer = partial(create, model=Composer)
-create_collection = partial(create, model=Collection)
-
 read_song = partial(read, model=Song)
-read_composer = partial(read, model=Composer)
-read_collection = partial(read, model=Collection)
-
 read_all_songs = partial(read_all, model=Song)
-read_all_composers = partial(read_all, model=Composer)
-read_all_collections = partial(read_all, model=Collection)
-
 update_song = partial(update, model=Song)
-update_composer = partial(update, model=Composer)
-update_collection = partial(update, model=Collection)
-
 delete_song = partial(delete, model=Song)
+
+create_composer = partial(create, model=Composer)
+read_composer = partial(read, model=Composer)
+read_all_composers = partial(read_all, model=Composer)
+update_composer = partial(update, model=Composer)
 delete_composer = partial(delete, model=Composer)
+
+create_collection = partial(create, model=Collection)
+read_collection = partial(read, model=Collection)
+read_all_collections = partial(read_all, model=Collection)
+update_collection = partial(update, model=Collection)
 delete_collection = partial(delete, model=Collection)

--- a/graph/lib/crud.py
+++ b/graph/lib/crud.py
@@ -1,0 +1,71 @@
+from functools import partial
+from typing import Type
+
+from .models import CreateModelType, UpdateModelType, ModelType
+from .models import Song, Composer, Collection
+from . import dynamodb as db
+
+
+def create(data: CreateModelType, model: Type[ModelType]) -> ModelType:
+    # get the id and form pk & sk
+    kind = model.__kind__
+    id = db._get_next_id(kind)
+    pk = kind
+    sk = f"{kind}:{id}"
+
+    item_in = model(**data.model_dump(), pk=pk, sk=sk)
+
+    item = db.put(item_in.model_dump())
+
+    # it is a bit funky that we don't return the object from the db, but eh
+    return item_in
+
+
+def read(id: int, model: Type[ModelType]) -> ModelType:
+    pk = model.__kind__
+    sk = f"{pk}:{id}"
+    item = db.get_item(pk, sk)
+
+    return model(**item)
+
+
+def update(id: int, data: UpdateModelType, model: Type[ModelType]) -> ModelType:
+    kind = model.__kind__
+    db_record = db.get_item(kind, f"{kind}:{id}")
+
+    updated = model(
+        **{
+            **db_record,
+            **data.model_dump(),
+        }
+    )
+
+    item = db.put(updated.model_dump())
+
+    return updated
+
+
+def delete(id: int, model: Type[ModelType]) -> ModelType:
+    pk = model.__kind__
+    sk = f"{pk}:{id}"
+
+    return model(**db.delete(pk, sk))
+
+
+# these do not properly bind to the appropriate create and update types, but
+# this shall be considered later
+create_song = partial(create, model=Song)
+create_composer = partial(create, model=Composer)
+create_collection = partial(create, model=Collection)
+
+read_song = partial(read, model=Song)
+read_composer = partial(read, model=Composer)
+read_collection = partial(read, model=Collection)
+
+update_song = partial(update, model=Song)
+update_composer = partial(update, model=Composer)
+update_collection = partial(update, model=Collection)
+
+delete_song = partial(delete, model=Song)
+delete_composer = partial(delete, model=Composer)
+delete_collection = partial(delete, model=Collection)

--- a/graph/lib/crud.py
+++ b/graph/lib/crud.py
@@ -83,6 +83,14 @@ def get_random_song() -> Song:
     return Song(**db.random("song"))
 
 
+def delete_song_cascade(id: int) -> int:
+    keys = db.reverse_index(sk=f"song:{id}")
+
+    db.batch_delete(keys)
+
+    return id
+
+
 create_composer = partial(create, model=Composer)
 read_composer = partial(read, model=Composer)
 read_all_composers = partial(read_all, model=Composer)

--- a/graph/lib/dynamodb.py
+++ b/graph/lib/dynamodb.py
@@ -86,6 +86,14 @@ def search(kind: Kind, string: str) -> dict | None:
     return result.get("Items")
 
 
+def reverse_index(sk: str) -> list[dict]:
+    result = TABLE.query(
+        IndexName=REVERSE_INDEX, KeyConditionExpression=Key("sk").eq(sk)
+    )
+
+    return result.get("Items")
+
+
 def _random(kind: Kind) -> dict | None:
     """Try getting a random record. Doesn't necessarily return a record due to
     the way things are implemented in the db.

--- a/graph/lib/dynamodb.py
+++ b/graph/lib/dynamodb.py
@@ -24,6 +24,12 @@ class Kind(StrEnum):
     collection = auto()
 
 
+def exists(pk: str, sk: str) -> bool:
+    # limit return value to sk to save on bandwith
+    item = TABLE.get_item(Key={"pk": pk, "sk": sk}, ProjectionExpression="sk")
+    return "Item" in item
+
+
 def get_item(pk: str, sk: str) -> dict | None:
     """Get an item by the primary key"""
     result = TABLE.get_item(Key={"pk": pk, "sk": sk})

--- a/graph/lib/dynamodb.py
+++ b/graph/lib/dynamodb.py
@@ -1,4 +1,7 @@
-"""Wrapper module around boto3 to simplify interaction with the db"""
+"""Wrapper module around boto3 to simplify interaction with the db.
+Mostly meant to simplify calls by hiding implementation details of the
+particular DynamoDB table implementation, while still being relatively thin.
+"""
 
 from decimal import Decimal
 import random as rand
@@ -44,9 +47,9 @@ def batch_delete(keys: list[dict]) -> list[dict]:
     return responses
 
 
-def list_kind(kind: Kind) -> list[dict]:
-    """Get all items of a kind"""
-    result = TABLE.query(KeyConditionExpression=Key("pk").eq(kind))
+def get_partition(pk: str) -> list[dict]:
+    """Get all items in a partition"""
+    result = TABLE.query(KeyConditionExpression=Key("pk").eq(pk))
 
     return result.get("Items", [])
 
@@ -97,18 +100,7 @@ def random(kind: Kind) -> dict:
     return item
 
 
-# TODO: ponder on the questions posed in the docstring
 def put(item: dict) -> dict:
-    """This wrapper is very thin, but useful at least as a closure for TABLE.
-    Used for both creation and updating (whole) records.
-
-    The question is: should this module aim at being super generic and not know anything about the
-    implementation of the models? Or should it know stuff like generating id's when creating records
-    of certain `kind` (or even that `kind` exists at all)? Maybe it should be something in between.
-    DynamoDB is by nature always very implementation-bound, so perhaps this module should just
-    acknowledge that. A crud module might then just implement a nicer interface for the API to call.
-    """
-
     response = TABLE.put_item(Item=item)
 
     # TODO: might want to check for errors here

--- a/graph/lib/dynamodb.py
+++ b/graph/lib/dynamodb.py
@@ -118,8 +118,7 @@ def put(item: dict) -> dict:
 def delete(pk: str, sk: str) -> dict:
     deleted = TABLE.delete_item(Key={"pk": pk, "sk": sk}, ReturnValues="ALL_OLD")
 
-    # TODO: ensure that this record makes sense
-    return deleted
+    return deleted["Attributes"]
 
 
 def _peek_sequence(kind: Kind) -> int:

--- a/graph/lib/dynamodb.py
+++ b/graph/lib/dynamodb.py
@@ -39,12 +39,21 @@ def batch_get(keys: list[dict]) -> list[dict]:
     return response["Responses"].get(TABLE.table_name, [])
 
 
+def batch_write(items: list[dict]) -> list[dict]:
+    with TABLE.batch_writer() as batch:
+        responses = [batch.put_item(Item=item) for item in items]
+
+    # put_item never returns any data, so we just return the items ¯\_(ツ)_/¯
+    return items
+
+
 def batch_delete(keys: list[dict]) -> list[dict]:
 
     with TABLE.batch_writer() as batch:
         responses = [batch.delete_item(Key=key) for key in keys]
 
-    return responses
+    # delete_item doesn't return data, so we just return the keys
+    return keys
 
 
 def get_partition(pk: str) -> list[dict]:

--- a/graph/lib/dynamodb.py
+++ b/graph/lib/dynamodb.py
@@ -62,9 +62,10 @@ def batch_delete(keys: list[dict]) -> list[dict]:
     return keys
 
 
-def get_partition(pk: str) -> list[dict]:
+# not super excited about the kwargs here but eh
+def get_partition(pk: str, **kwargs) -> list[dict]:
     """Get all items in a partition"""
-    result = TABLE.query(KeyConditionExpression=Key("pk").eq(pk))
+    result = TABLE.query(KeyConditionExpression=Key("pk").eq(pk), **kwargs)
 
     return result.get("Items", [])
 

--- a/graph/lib/hankkari.py
+++ b/graph/lib/hankkari.py
@@ -11,7 +11,7 @@ NATURALS = {
 ACCIDENTALS = {"#": 1, "b": -1, "x": 2}
 
 
-def parse_note(note):
+def parse_note(note: str) -> float:
     tone, *accidents, octave = note
 
     return (
@@ -19,10 +19,10 @@ def parse_note(note):
     )
 
 
-def profile(tones):
+def profile(tones: list[str]) -> list[float]:
     first, *rest = map(parse_note, tones)
     return [0] + [tone - first for tone in rest]
 
 
-def is_hankkari(tones):
+def is_hankkari(tones: list[str]) -> bool:
     return profile(tones) == [0, -4, -9, -16]

--- a/graph/lib/models.py
+++ b/graph/lib/models.py
@@ -1,0 +1,137 @@
+from decimal import Decimal
+from functools import partial
+import random
+from typing import ClassVar, Protocol, Type, TypeVar
+from pydantic import BaseModel, computed_field, Field
+
+
+CreateModelType = TypeVar("CreateModelType", bound=BaseModel)
+
+
+class ModelType(Protocol):
+    __kind__: ClassVar[str]
+
+
+class KeySchema(BaseModel):
+    """Everything in the DynamoDB has a partition key and a sort key"""
+
+    pk: str
+    sk: str
+
+
+class Record(KeySchema):
+    """Granted, a bit of a generic name, but this is mostly to differentiate
+    between the records relevant to the user (Song, Composer, Collection) and
+    the internal things (like opus, membership, sequence)
+    """
+
+    name: str
+    random: Decimal
+
+    @computed_field
+    @property
+    def id(self) -> int:
+        return int(self.sk.split(":")[1])
+
+    @computed_field
+    @property
+    def search_name(self) -> str:
+        return self.name.lower()
+
+
+class Song(Record):
+    __kind__: ClassVar[str] = "song"
+
+    tones: str
+
+
+class Composer(Record):
+    __kind__: ClassVar[str] = "composer"
+
+    first_name: str | None = None
+    last_name: str
+
+
+class Collection(Record):
+    __kind__: ClassVar[str] = "collection"
+
+
+class RecordCreate(BaseModel):
+    random: str = Field(default_factory=lambda: Decimal(str(random.random())))
+
+    @computed_field
+    @property
+    def search_name(self) -> str:
+        """This is a bit of a bad pattern, as it assumes that subclasses implement `name`
+        This is due to Composer being a bit janky - couldn't yet find a way to override
+        a superclass attribute with a computed field. Alternative would be to instead
+        just provide the full name and parse first_name and last_name from it instead.
+        """
+        return self.name.lower()
+
+
+class SongCreate(RecordCreate):
+    name: str
+    tones: str
+
+
+class ComposerCreate(RecordCreate):
+    first_name: str | None = None
+    last_name: str
+
+    @computed_field
+    @property
+    def name(self) -> str:
+        return self.last_name + (f", {self.first_name}" if self.first_name else "")
+
+
+class CollectionCreate(RecordCreate):
+    name: str
+
+
+# crud stuff - shall be moved eventually
+from . import dynamodb as db
+
+
+def create(data: CreateModelType, model: Type[ModelType]) -> ModelType:
+    # get the id and form pk & sk
+    kind = model.__kind__
+    # id = db._get_next_id(kind)
+    id = 123
+    pk = kind
+    sk = f"{kind}:{id}"
+
+    item_in = model(**data.model_dump(), pk=pk, sk=sk)
+
+    # db.put(...)
+
+    return item_in
+
+
+def read(id: int, model: Type[ModelType]) -> ModelType:
+    pk = model.__kind__
+    sk = f"{pk}:{id}"
+    item = db.get_item(pk, sk)
+
+    return model(**item)
+
+
+def update():
+    raise NotImplementedError
+
+
+def delete(id: int, model: Type[ModelType]) -> ModelType:
+    pk = model.__kind__
+    sk = f"{pk}:{id}"
+
+    print("Would now delete", pk, sk)
+    # return model(**db.delete(pk, sk))
+
+
+create_song = partial(create, model=Song)
+create_composer = partial(create, model=Composer)
+create_collection = partial(create, model=Collection)
+
+read_song = partial(read, model=Song)
+read_composer = partial(read, model=Composer)
+read_collection = partial(read, model=Collection)

--- a/graph/lib/models.py
+++ b/graph/lib/models.py
@@ -20,6 +20,11 @@ class KeySchema(BaseModel):
     sk: str
 
 
+class SearchResult(KeySchema):
+    name: str
+    search_name: str
+
+
 class Membership(KeySchema):
     """A membership record connects Songs to Groups (Collections and Composers)"""
 

--- a/graph/lib/models.py
+++ b/graph/lib/models.py
@@ -20,6 +20,21 @@ class KeySchema(BaseModel):
     sk: str
 
 
+class Membership(KeySchema):
+    """A membership record connects Songs to Groups (Collections and Composers)"""
+
+    name: str
+    tones: str
+
+    @property
+    def group_id(self) -> int:
+        return int(self.pk.split(":")[1])
+
+    @property
+    def song_id(self) -> int:
+        return int(self.sk.split(":")[1])
+
+
 class Record(ModelType, KeySchema):
     """Granted, a bit of a generic name, but this is mostly to differentiate
     between the records relevant to the user (Song, Composer, Collection) and

--- a/graph/lib/opus.py
+++ b/graph/lib/opus.py
@@ -1,3 +1,5 @@
+"""It is debatable whether this should be its own module or a part of crud.py"""
+
 import json
 import boto3
 from . import dynamodb as db

--- a/graph/lib/opus.py
+++ b/graph/lib/opus.py
@@ -11,6 +11,10 @@ def get(tones: str) -> dict | None:
     return db.get_item("opus", tones)
 
 
+def exists(tones: str) -> bool:
+    return db.exists("opus", tones)
+
+
 def create(tones: str) -> None:
     tones_list = tones.split("-")
 

--- a/graph/lib/schema.py
+++ b/graph/lib/schema.py
@@ -225,11 +225,17 @@ class Mutation:
         return result
 
     @strawberry.mutation
-    def create_composer(self, composer: ComposerInput) -> Composer:
+    def create_composer(
+        self, composer: ComposerInput, songs: list[int] | None = None
+    ) -> Composer:
         composerdict = strawberry.asdict(composer)
         composer_model = models.ComposerCreate(**composerdict)
 
         db_composer = crud.create_composer(composer_model)
+
+        # add songs
+        songs_ = songs or []
+        crud.create_memberships(Kind.composer, db_composer.id, songs_)
 
         return Composer(**db_composer.model_dump())
 
@@ -252,11 +258,17 @@ class Mutation:
         return id
 
     @strawberry.mutation
-    def create_collection(self, collection: CollectionInput) -> Collection:
+    def create_collection(
+        self, collection: CollectionInput, songs: list[int] | None = None
+    ) -> Collection:
         collectiondict = strawberry.asdict(collection)
         collection_model = models.CollectionCreate(**collectiondict)
 
         db_collection = crud.create_collection(collection_model)
+
+        # add songs
+        songs_ = songs or []
+        crud.create_memberships(Kind.collection, db_collection.id, songs_)
 
         return Collection(**db_collection.model_dump())
 

--- a/graph/lib/schema.py
+++ b/graph/lib/schema.py
@@ -246,10 +246,10 @@ class Mutation:
         return Composer(**db_composer.model_dump())
 
     @strawberry.mutation
-    def delete_composer(self, id: int) -> Composer:
-        db_composer = crud.delete_composer(id)
+    def delete_composer(self, id: int) -> int:
+        crud.delete_composer_cascade(id)
 
-        return Composer(**db_composer.model_dump())
+        return id
 
     @strawberry.mutation
     def create_collection(self, collection: CollectionInput) -> Collection:
@@ -269,9 +269,9 @@ class Mutation:
         return Collection(**db_collection.model_dump())
 
     @strawberry.mutation
-    def delete_collection(self, id: int) -> Collection:
-        db_collection = crud.delete_collection(id)
-        return Collection(**db_collection.model_dump())
+    def delete_collection(self, id: int) -> int:
+        crud.delete_collection_cascade(id)
+        return id
 
     @strawberry.mutation
     def add_membership(

--- a/graph/lib/schema.py
+++ b/graph/lib/schema.py
@@ -178,6 +178,17 @@ class Mutation:
 
         db_song = crud.create_song(song_model)
 
+        # TODO: it would be really cool if this were async. Although,
+        # a user might request for the value already when creating, in which case async
+        # isn't really useful.
+        # check for opus and create if needed
+        if not opus.exists(song.tones):
+            print("Creating new opus for", song.tones)
+            opus.create(song.tones)
+            print("Created new opus for", song.tones)
+        else:
+            print("Found existing opus for", song.tones)
+
         return Song(**db_song.model_dump())
 
     @strawberry.mutation

--- a/graph/lib/schema.py
+++ b/graph/lib/schema.py
@@ -3,6 +3,7 @@ import random as rand
 import strawberry
 from strawberry.asgi import GraphQL
 from mangum import Mangum
+from lib import crud
 from lib import dynamodb as db
 from lib import opus
 from enum import StrEnum, auto
@@ -73,21 +74,19 @@ class Collection(Record, Group):
     pass
 
 
-def get_one_of_kind(kind: db.Kind, id: int):
-    sk = f"{kind}:{id}"
-    return db.get_item(kind, sk)
-
-
 def get_song(id: int) -> Song:
-    return Song(**get_one_of_kind(db.Kind.song, id))
+    obj = crud.read_song(id)
+    return Song(**obj.model_dump())
 
 
 def get_composer(id: int) -> Composer:
-    return Composer(**get_one_of_kind(db.Kind.composer, id))
+    obj = crud.read_composer(id)
+    return Composer(**obj.model_dump())
 
 
 def get_collection(id: int) -> Collection:
-    return Collection(**get_one_of_kind(db.Kind.collection, id))
+    obj = crud.read_collection(id)
+    return Collection(**obj.model_dump())
 
 
 def resolve_opus(tones: str):

--- a/graph/lib/schema.py
+++ b/graph/lib/schema.py
@@ -249,6 +249,22 @@ class Mutation:
         db_collection = crud.delete_collection(id)
         return Collection(**db_collection.model_dump())
 
+    @strawberry.mutation
+    def add_membership(
+        self, kind: Kind, group_id: int, song_ids: list[int]
+    ) -> list[int]:
+        records = crud.create_memberships(kind, group_id, song_ids)
+
+        return [record.song_id for record in records]
+
+    @strawberry.mutation
+    def remove_membership(
+        self, kind: Kind, group_id: int, song_ids: list[int]
+    ) -> list[int]:
+        keys = crud.delete_memberships(kind, group_id, song_ids)
+
+        return [int(key["sk"].split(":")[1]) for key in keys]
+
 
 schema = strawberry.Schema(query=Query, mutation=Mutation)
 app = GraphQL(schema)

--- a/graph/lib/schema.py
+++ b/graph/lib/schema.py
@@ -111,7 +111,7 @@ class Query:
     def search(self, kind: Kind, string: str) -> list[Record]:
         if not string:
             # `kind` is technically of the wrong type for db.list_kind
-            records = sorted(db.list_kind(kind), key=lambda x: x["name"])
+            records = sorted(db.get_partition(kind), key=lambda x: x["name"])
 
         else:
             records = db.search(kind, string)

--- a/graph/lib/schema.py
+++ b/graph/lib/schema.py
@@ -124,9 +124,9 @@ class Query:
 
     @strawberry.field
     def random_song(self) -> Song:
-        item = db.random(db.Kind.song)
+        item = crud.get_random_song()
 
-        return Song(**item)
+        return Song(**item.model_dump())
 
     @strawberry.field
     def search(self, kind: Kind, string: str) -> list[Record]:

--- a/graph/lib/schema.py
+++ b/graph/lib/schema.py
@@ -215,6 +215,10 @@ class Mutation:
 
         db_song = crud.update_song(id, song_model)
 
+        # ensure that membership records are updated as well
+        # (this is needed due to denormalization)
+        crud.update_song_memberships(id, song_model)
+
         return Song(**db_song.model_dump())
 
     @strawberry.mutation

--- a/graph/lib/schema.py
+++ b/graph/lib/schema.py
@@ -218,10 +218,11 @@ class Mutation:
         return Song(**db_song.model_dump())
 
     @strawberry.mutation
-    def delete_song(self, id: int) -> Song:
-        db_song = crud.delete_song(id)
+    def delete_song(self, id: int) -> int:
+        """Deletes song and all it's memberships"""
+        result = crud.delete_song_cascade(id)
 
-        return Song(**db_song.model_dump())
+        return result
 
     @strawberry.mutation
     def create_composer(self, composer: ComposerInput) -> Composer:


### PR DESCRIPTION
API now supports also creating, updating, and deleting records.
- when creating songs, one can specify composer and collection ids it belongs to, and the appropriate membership records get created
- similarly, when creating  composers and collection, one can "register" songs to them
- updating songs cascades into membership records (needed due to denormalization)
- deleting songs / collections / composers, the delete cascades into membership records

Certain issues remain:
- typing probably isn't entirely correct. Will probably fix when looking into mypy in more detail
- API should probably return empty / error values when trying to access a non-existing id
- composers / collections can't be _created_ during song creation and vice-versa. Consider whether this would be useful
  -  mostly a nice convenience, but could simplify / reduce some client calls
