### PR TITLE
14 search index should project tones

### DIFF
--- a/etl-tools/core.py
+++ b/etl-tools/core.py
@@ -21,6 +21,12 @@ def load_dump(file: Path) -> Dump:
         # parse numbers to Decimal, because that is what DynamoDB wants
         data = json.load(f, parse_float=Decimal, parse_int=Decimal)
 
+        for row in data:
+            if row["pk"] != "opus":
+                continue
+
+            row["opus"] = row["opus"].encode()
+
     return data
 
 

--- a/graph/lib/crud.py
+++ b/graph/lib/crud.py
@@ -2,14 +2,14 @@ from functools import partial
 from typing import Type
 
 from .models import CreateModelType, UpdateModelType, ModelType
-from .models import Song, SongUpdate, Composer, Collection, Membership, SearchResult
+from .models import Song, SongUpdate, Composer, Collection, Membership
 from . import dynamodb as db
 
 
-def search(kind: str, string: str) -> SearchResult:
-    items = db.search(kind, string)
+def search(string: str, model: Type[ModelType]) -> ModelType:
+    items = db.search(model.__kind__, string)
 
-    return [SearchResult(**item) for item in items]
+    return [model(**item) for item in items]
 
 
 def create(data: CreateModelType, model: Type[ModelType]) -> ModelType:
@@ -86,6 +86,7 @@ read_song = partial(read, model=Song)
 read_all_songs = partial(read_all, model=Song)
 update_song = partial(update, model=Song)
 delete_song = partial(delete, model=Song)
+search_song = partial(search, model=Song)
 
 
 def get_random_song() -> Song:
@@ -126,6 +127,7 @@ update_composer = partial(update, model=Composer)
 delete_composer = partial(delete, model=Composer)
 get_composer_songs = partial(get_group_songs, kind="composer")
 delete_composer_cascade = partial(delete_group_cascade, kind="composer")
+search_composer = partial(search, model=Composer)
 
 create_collection = partial(create, model=Collection)
 read_collection = partial(read, model=Collection)
@@ -134,6 +136,7 @@ update_collection = partial(update, model=Collection)
 delete_collection = partial(delete, model=Collection)
 get_collection_songs = partial(get_group_songs, kind="collection")
 delete_collection_cascade = partial(delete_group_cascade, kind="collection")
+search_collection = partial(search, model=Collection)
 
 
 def create_memberships(

--- a/graph/lib/models.py
+++ b/graph/lib/models.py
@@ -20,11 +20,6 @@ class KeySchema(BaseModel):
     sk: str
 
 
-class SearchResult(KeySchema):
-    name: str
-    search_name: str
-
-
 class Membership(KeySchema):
     """A membership record connects Songs to Groups (Collections and Composers)"""
 

--- a/infra/dynamo.tf
+++ b/infra/dynamo.tf
@@ -58,7 +58,7 @@ resource "aws_dynamodb_table" "songs-table-v2" {
     name               = "search_index"
     range_key          = "search_name"
     projection_type    = "INCLUDE"
-    non_key_attributes = ["name"]
+    non_key_attributes = ["name", "tones"]
   }
 
   local_secondary_index {

--- a/infra/dynamo.tf
+++ b/infra/dynamo.tf
@@ -55,10 +55,9 @@ resource "aws_dynamodb_table" "songs-table-v2" {
   }
 
   local_secondary_index {
-    name               = "search_index"
-    range_key          = "search_name"
-    projection_type    = "INCLUDE"
-    non_key_attributes = ["name", "tones"]
+    name            = "search_index"
+    range_key       = "search_name"
+    projection_type = "ALL"
   }
 
   local_secondary_index {


### PR DESCRIPTION
Decided to project all attributes instead of just tones. This helped simplify searching composers, as now also the `first_name` and `last_name` are available.

`crud.py` is quite unwieldly, with shaky typing and some duplication, which also cascades to `schema.py` - this will probably pop up when static type checking with mypy is eventually implemented, so it'll likely be addressed then.