### PR TITLE
1 consider graphql querying library for telegram bot

### DIFF
--- a/telegram/lib/service.py
+++ b/telegram/lib/service.py
@@ -54,7 +54,7 @@ def get_song(song_id: int) -> dict:
     return song
 
 
-def get_songlist(group_pk: str):
+def get_songlist(group_pk: str) -> list[dict]:
     """Splitting the pk here is a bit smelly"""
     kind, num = group_pk.split(":")
 
@@ -72,7 +72,7 @@ def get_songlist(group_pk: str):
     return result["data"][kind]["songs"]
 
 
-def get_random_song():
+def get_random_song() -> dict:
     q = "{randomSong {id, name, tones, opus}}"
     result = query(q)
     song = result["data"]["randomSong"]

--- a/telegram/lib/service.py
+++ b/telegram/lib/service.py
@@ -14,25 +14,38 @@ class Kind(StrEnum):
 
 
 # graph api wrapper implementation
-def query(q: str):
-    return httpx.post(APIURL, json={"query": q}).json()
+def query(q: str, vars: dict | None = None) -> dict:
+
+    return httpx.post(APIURL, json={"query": q, "variables": vars}).json()
 
 
-def search(kind: Kind, search_string: str):
-    q = f"""
-    {{
-        search (kind: {kind}, string: "{search_string}") {{
-            id, name
-        }}
-    }}"""
-    result = query(q)
+def search(kind: Kind, search_string: str) -> dict:
+    q = """
+    query search($kind: Kind!, $string: String!){
+        search(kind: $kind string: $string) {
+            id
+            name
+         }
+    }
+    """
+
+    result = query(q, {"kind": kind, "string": search_string})
 
     return result["data"]["search"]
 
 
-def get_song(song_id: int):
-    q = f"""{{song (id: {song_id}) {{ id, name, tones, opus }} }}"""
-    result = query(q)
+def get_song(song_id: int) -> dict:
+    q = """
+    query getSong($id: Int!) {
+        song (id: $id){
+            id
+            name
+            tones
+            opus
+        }
+    }
+    """
+    result = query(q, {"id": song_id})
     song = result["data"]["song"]
 
     # convert opus to bytestream
@@ -45,17 +58,16 @@ def get_songlist(group_pk: str):
     """Splitting the pk here is a bit smelly"""
     kind, num = group_pk.split(":")
 
-    q = f"""
-    {{
-        {kind} (id: {num}) {{
-            songs {{
-                id, name
-            }}
-        }}
-    }}
-    """
+    # string manipulation a bit hacky but I guess it's better than double braces
+    q = """
+    query listSongs($id: Int!) {
+        %(kind)s (id: $id) { songs { id name } }
+    }
+    """ % {
+        "kind": kind
+    }
 
-    result = query(q)
+    result = query(q, {"id": int(num)})
 
     return result["data"][kind]["songs"]
 

--- a/telegram/lib/service.py
+++ b/telegram/lib/service.py
@@ -13,6 +13,14 @@ class Kind(StrEnum):
     collection = auto()
 
 
+def convert_song_opus(song: dict) -> dict:
+    """Converts the API's opus data to IO[bytes]"""
+    return {
+        **song,
+        "opus": BytesIO(base64.b64decode(song["opus"])),
+    }
+
+
 # graph api wrapper implementation
 def query(q: str, vars: dict | None = None) -> dict:
 
@@ -48,10 +56,7 @@ def get_song(song_id: int) -> dict:
     result = query(q, {"id": song_id})
     song = result["data"]["song"]
 
-    # convert opus to bytestream
-    opus = BytesIO(base64.b64decode(song["opus"]))
-    song["opus"] = opus
-    return song
+    return convert_song_opus(song)
 
 
 def get_songlist(group_pk: str) -> list[dict]:
@@ -77,7 +82,4 @@ def get_random_song() -> dict:
     result = query(q)
     song = result["data"]["randomSong"]
 
-    # convert opus to bytestream
-    opus = BytesIO(base64.b64decode(song["opus"]))
-    song["opus"] = opus
-    return song
+    return convert_song_opus(song)


### PR DESCRIPTION
Considered - decided not to.

The main gripe from before was needing to use double curly braces within f-strings. The simple solution is to avoid using f-string by leveraging graphql variables instead. Granted, `telegram.lib.service.get_songlist` is a bit kinky due to "the good old way" of string formatting, but it is much more readable than double curlies. This could be potentially solved by implementing a custom directive, but that feels like overkill / misuse - it is at the end of the day the client who is cutting corners here. 